### PR TITLE
Now, cursors of coauthors are hidden when change project

### DIFF
--- a/src/bin/scenarist-core/UserInterfaceLayer/ScenarioTextEdit/ScenarioTextEdit.cpp
+++ b/src/bin/scenarist-core/UserInterfaceLayer/ScenarioTextEdit/ScenarioTextEdit.cpp
@@ -89,6 +89,12 @@ void ScenarioTextEdit::setScenarioDocument(ScenarioTextDocument* _document)
 {
 	removeEditorConnections();
 
+    //
+    // Удалим курсоры
+    //
+    m_additionalCursors.clear();
+    m_additionalCursorsCorrected.clear();
+
 	m_document = _document;
 	setDocument(m_document);
 	setHighlighterDocument(m_document);


### PR DESCRIPTION
#4 Поправил. Теперь при любой смене проекта, предыдущие курсоры пропадают.