### PR TITLE
Fix cloud renaming

### DIFF
--- a/src/bin/scenarist-core/3rd_party/Helpers/BackupHelper.cpp
+++ b/src/bin/scenarist-core/3rd_party/Helpers/BackupHelper.cpp
@@ -42,7 +42,7 @@ void BackupHelper::setBackupDir(const QString& _dir)
 	}
 }
 
-void BackupHelper::saveBackup(const QString& _filePath)
+void BackupHelper::saveBackup(const QString& _filePath, const QString& _newName)
 {
 	if (m_isActive
 		&& !m_isInProgress) {
@@ -62,12 +62,13 @@ void BackupHelper::saveBackup(const QString& _filePath)
 		}
 
 		QFileInfo fileInfo(_filePath);
-		const QString tmpBackupFileName =
-				QString("%1%2.backup.tmp.%3").arg(backupPath, fileInfo.completeBaseName(), fileInfo.completeSuffix());
+        const QString backupBaseName = _newName.isEmpty() ? fileInfo.completeBaseName() : _newName;
+        const QString tmpBackupFileName =
+                QString("%1%2.backup.tmp.%3").arg(backupPath, backupBaseName, fileInfo.completeSuffix());
 		const QString backupFileName =
-				QString("%1%2.full.backup.%3").arg(backupPath, fileInfo.completeBaseName(), fileInfo.completeSuffix());
+                QString("%1%2.full.backup.%3").arg(backupPath, backupBaseName, fileInfo.completeSuffix());
 		const QString backupVersionsFileName =
-				QString("%1%2.versions.backup.%3").arg(backupPath, fileInfo.completeBaseName(), BACKUP_VERSIONS_EXTENSION);
+                QString("%1%2.versions.backup.%3").arg(backupPath, backupBaseName, BACKUP_VERSIONS_EXTENSION);
 
 		//
 		// Копируем файл во временную резервную копию

--- a/src/bin/scenarist-core/3rd_party/Helpers/BackupHelper.h
+++ b/src/bin/scenarist-core/3rd_party/Helpers/BackupHelper.h
@@ -25,7 +25,7 @@ public:
 	/**
 	 * @brief Создать резервную копию файла
 	 */
-	void saveBackup(const QString& _filePath);
+    void saveBackup(const QString& _filePath, const QString& _newName = "");
 
 private:
 	/**

--- a/src/bin/scenarist-core/ManagementLayer/Project/Project.cpp
+++ b/src/bin/scenarist-core/ManagementLayer/Project/Project.cpp
@@ -80,10 +80,9 @@ Project::Project(Type _type, const QString& _name, const QString& _path,
 		// ... формируем путь к файлу проекта
 		//
 		m_path =
-			QString("%1%2%3 [%4]%5")
+            QString("%1%2%3%4")
 				.arg(remoteProjectsFolderPath)
 				.arg(QDir::separator())
-				.arg(m_name)
 				.arg(m_id)
 				.arg(PROJECT_FILE_EXTENSION);
 		//

--- a/src/bin/scenarist-desktop/ManagementLayer/ApplicationManager.cpp
+++ b/src/bin/scenarist-desktop/ManagementLayer/ApplicationManager.cpp
@@ -531,7 +531,12 @@ void ApplicationManager::aboutSave()
             //
             // Если необходимо создадим резервную копию закрываемого файла
             //
-            QtConcurrent::run(&m_backupHelper, &BackupHelper::saveBackup, ProjectsManager::currentProject().path());
+            QString baseBackupName = "";
+            const Project& currentProject = ProjectsManager::currentProject();
+            if (currentProject.isRemote()) {
+                baseBackupName = QString("%1 [%2]").arg(currentProject.name()).arg(currentProject.id());
+            }
+            QtConcurrent::run(&m_backupHelper, &BackupHelper::saveBackup, ProjectsManager::currentProject().path(), baseBackupName);
         }
         //
         // А если ошибка сохранения, то делаем дополнительные проверки и работаем с пользователем
@@ -794,6 +799,7 @@ void ApplicationManager::editRemoteProjectName(const QModelIndex& _index)
                 tr("Enter new name for project"), project.name());
     if (!newName.isEmpty()) {
         m_synchronizationManager->updateProjectName(project.id(), newName);
+        m_projectsManager->setCurrentProjectName(newName);
     }
 }
 

--- a/src/bin/scenarist-desktop/ManagementLayer/ApplicationManager.cpp
+++ b/src/bin/scenarist-desktop/ManagementLayer/ApplicationManager.cpp
@@ -534,6 +534,10 @@ void ApplicationManager::aboutSave()
             QString baseBackupName = "";
             const Project& currentProject = ProjectsManager::currentProject();
             if (currentProject.isRemote()) {
+                //
+                // Для удаленных проектов имя бекапа - имя проекта + id проекта
+                // В случае, если имя удаленного проекта изменилось, то бэкапы со старым именем останутся навсегда
+                //
                 baseBackupName = QString("%1 [%2]").arg(currentProject.name()).arg(currentProject.id());
             }
             QtConcurrent::run(&m_backupHelper, &BackupHelper::saveBackup, ProjectsManager::currentProject().path(), baseBackupName);


### PR DESCRIPTION
#307 Исправлено. Как было решено, удаленные проекты храним локально под именем id проекта. А бэкапы создаем уже под именем равным имени проекта + id